### PR TITLE
feat/filesize enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "az"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822d7d63e0c0260a050f6b1f0d316f5c79b9eab830aca526ed904e1011bd64ca"
-
-[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,16 +20,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c909eb55443867ff73a36c7c28784f02496e657c9618cdfed0c70a8379b911a"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "indicatif"
@@ -87,18 +71,6 @@ name = "rm-modules"
 version = "0.1.0"
 dependencies = [
  "indicatif",
- "rug",
-]
-
-[[package]]
-name = "rug"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0c6e98de59509e62e09f3456b23cebb75dad21928882016f169bb628843459"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rug = "1.13"
 indicatif = "0.16.2"

--- a/src/init.rs
+++ b/src/init.rs
@@ -30,6 +30,7 @@ pub fn run(config: Config) -> Result<NodeModuleMap, RmError> {
             // bytes to mb on total val
             nm_map.total_size += FileSize::MB.get_value(all_dirs_size);
             r.spinner.end();
+
             Ok(nm_map)
         }
         Err(_) => Err(RmError::Io),

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,8 +1,6 @@
 use crate::{error::RmError, recursive::Recursive, utils, Config, FileSize, NodeModuleMap};
 use std::path::Path;
 
-use rug::Float;
-
 // Run the program
 pub fn run(config: Config) -> Result<NodeModuleMap, RmError> {
     // Check target_dir
@@ -16,22 +14,21 @@ pub fn run(config: Config) -> Result<NodeModuleMap, RmError> {
     match r.search(path, &mut nm_map) {
         Ok(_) => {
             // Store size of node_module folders
-            let mut all_dirs_size = Float::new(32);
-
+            let mut all_dirs_size = 0.0;
             r.spinner.set_count_style();
 
             for dir in &mut nm_map.dirs {
-                let mut dir_size = dir.1.clone();
+                let mut dir_size = *dir.1;
                 dir_size += r.count(dir.0)?;
 
                 // Add individual dir_size to total
                 all_dirs_size += dir_size;
                 r.spinner
-                    .msg((FileSize::MB.calculate(all_dirs_size)).to_string());
+                    .msg(format!("{:.2}", FileSize::MB.get_value(all_dirs_size)));
             }
-            
+
             // bytes to mb on total val
-            nm_map.total_size += FileSize::MB.calculate(all_dirs_size);
+            nm_map.total_size += FileSize::MB.get_value(all_dirs_size);
             r.spinner.end();
             Ok(nm_map)
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,4 +1,4 @@
-use crate::{error::RmError, recursive::Recursive, utils, Config, NodeModuleMap};
+use crate::{error::RmError, recursive::Recursive, utils, Config, FileSize, NodeModuleMap};
 use std::path::Path;
 
 use rug::Float;
@@ -26,14 +26,12 @@ pub fn run(config: Config) -> Result<NodeModuleMap, RmError> {
 
                 // Add individual dir_size to total
                 all_dirs_size += dir_size;
-                r.spinner.msg(
-                    (&all_dirs_size / Float::with_val(32, 1000) / Float::with_val(32, 1000))
-                        .to_string(),
-                );
+                r.spinner
+                    .msg((FileSize::MB.calculate(all_dirs_size)).to_string());
             }
-
+            
             // bytes to mb on total val
-            nm_map.total_size += all_dirs_size / 1000 / 1000;
+            nm_map.total_size += FileSize::MB.calculate(all_dirs_size);
             r.spinner.end();
             Ok(nm_map)
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,4 +1,4 @@
-use crate::{error::RmError, recursive::Recursive, utils, Config, FileSize, NodeModuleMap};
+use crate::{error::RmError, utils, walk::Walk, Config, FileSize, NodeModuleMap};
 use std::path::Path;
 
 // Run the program
@@ -6,7 +6,7 @@ pub fn run(config: Config) -> Result<NodeModuleMap, RmError> {
     // Check target_dir
     utils::is_directory_valid(&config.target_dir)?;
 
-    let r = Recursive::new(&config.target_dir)?;
+    let r = Walk::new(&config.target_dir)?;
     let mut nm_map = NodeModuleMap::new();
 
     // search and on ok count

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use error::RmError;
-use rug::Float;
 use std::{collections::HashMap, path::PathBuf};
 
 pub mod error;
@@ -28,8 +27,8 @@ impl Config {
 #[derive(Debug)]
 pub struct NodeModuleMap {
     folder_count: u32,
-    dirs: HashMap<PathBuf, Float>,
-    pub total_size: Float,
+    dirs: HashMap<PathBuf, f64>,
+    pub total_size: f64,
 }
 
 impl NodeModuleMap {
@@ -37,15 +36,17 @@ impl NodeModuleMap {
         NodeModuleMap {
             dirs: HashMap::new(),
             folder_count: 0,
-            total_size: Float::new(32),
+            total_size: 0.0,
         }
     }
 
     fn add(&mut self, entry: PathBuf) {
-        self.dirs.insert(entry, Float::new(32));
+        self.dirs.insert(entry, 0.0);
         self.folder_count += 1;
     }
 }
+
+#[allow(dead_code)]
 enum FileSize {
     B,
     KB,
@@ -54,13 +55,12 @@ enum FileSize {
 }
 
 impl FileSize {
-    fn calculate(&self, val: Float) -> Float {
-        let thousand = Float::with_val(32, 1000);
+    fn get_value(&self, val: f64) -> f64 {
         match self {
-            FileSize::B => return val,
-            FileSize::KB => return val / &thousand,
-            FileSize::MB => return val / &thousand / &thousand,
-            FileSize::GB => return val / &thousand / &thousand / &thousand,
+            FileSize::B => val,
+            FileSize::KB => val / 1000_f64,
+            FileSize::MB => val / 1000_f64 / 1000_f64,
+            FileSize::GB => val / 1000_f64 / 1000_f64 / 1000_f64,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@ use std::{collections::HashMap, path::PathBuf};
 
 pub mod error;
 pub mod init;
-pub mod recursive;
 pub mod remove;
 pub mod spinner;
 pub mod utils;
+pub mod walk;
 
 pub struct Config {
     target_dir: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,23 +37,30 @@ impl NodeModuleMap {
         NodeModuleMap {
             dirs: HashMap::new(),
             folder_count: 0,
-            total_size: Float::with_val(32, 0.0),
+            total_size: Float::new(32),
         }
     }
 
     fn add(&mut self, entry: PathBuf) {
-        self.dirs.insert(entry, Float::with_val(32, 0.0));
+        self.dirs.insert(entry, Float::new(32));
         self.folder_count += 1;
     }
 }
+enum FileSize {
+    B,
+    KB,
+    MB,
+    GB,
+}
 
-// enum FolderType {
-//     NodeModules,
-// }
-
-// enum FileSize {
-//     B,
-//     KB,
-//     MB,
-//     GB,
-// }
+impl FileSize {
+    fn calculate(&self, val: Float) -> Float {
+        let thousand = Float::with_val(32, 1000);
+        match self {
+            FileSize::B => return val,
+            FileSize::KB => return val / &thousand,
+            FileSize::MB => return val / &thousand / &thousand,
+            FileSize::GB => return val / &thousand / &thousand / &thousand,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     });
 
     match init::run(config) {
-        Ok(result) => println!("Removed {} MB", result.total_size),
+        Ok(result) => println!("Removed {:.2} MB", result.total_size),
         Err(e) => {
             eprintln!("{:?}", e);
             process::exit(1);

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,7 +1,5 @@
 use std::{fs, os::macos::fs::MetadataExt, path::Path};
 
-use rug::Float;
-
 use crate::{error::RmError, spinner::Spinner, utils, NodeModuleMap};
 
 #[derive(Debug)]
@@ -49,10 +47,11 @@ impl Recursive {
         Ok(())
     }
 
-    pub fn count(&self, path: &Path) -> Result<Float, RmError> {
+    pub fn count(&self, path: &Path) -> Result<f64, RmError> {
         // @TODO: make block calc platform generic - currently unix/macos
         let entries = fs::read_dir(path)?.filter_map(Result::ok);
-        let mut total_size = Float::with_val(32, 0.0);
+        // let mut total_size = Float::with_val(32, 0.0);
+        let mut total_size = 0.0;
 
         for entry in entries {
             let file_path_buf = entry.path();
@@ -64,7 +63,8 @@ impl Recursive {
                 } else if file_type.is_dir() {
                     total_size += self.count(&file_path_buf)?;
                 } else {
-                    total_size += Float::with_val(32, attribs.st_blocks() * 512);
+                    let tmp_size = attribs.st_blocks() * 512;
+                    total_size += tmp_size as f64;
                 }
             }
         }

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -47,10 +47,9 @@ impl Recursive {
         Ok(())
     }
 
+    // @TODO: make block calc platform generic - currently unix/macos
     pub fn count(&self, path: &Path) -> Result<f64, RmError> {
-        // @TODO: make block calc platform generic - currently unix/macos
         let entries = fs::read_dir(path)?.filter_map(Result::ok);
-        // let mut total_size = Float::with_val(32, 0.0);
         let mut total_size = 0.0;
 
         for entry in entries {

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,11 +1,9 @@
-use rug::Float;
-
 use crate::NodeModuleMap;
 
 use std::fs;
 
-pub fn remove_folders(module_map: NodeModuleMap) -> std::io::Result<Float> {
-    let mut total_space = Float::with_val(32, 0.0);
+pub fn remove_folders(module_map: NodeModuleMap) -> std::io::Result<f64> {
+    let mut total_space = 0.0;
     for file in &module_map.dirs {
         total_space += file.1;
         fs::remove_dir_all(file.0)?;

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -3,12 +3,12 @@ use std::{fs, os::macos::fs::MetadataExt, path::Path};
 use crate::{error::RmError, spinner::Spinner, utils, NodeModuleMap};
 
 #[derive(Debug)]
-pub struct Recursive {
+pub struct Walk {
     pub dir: String,
     pub spinner: Spinner, // store: NodeModuleMap,
 }
 
-impl Recursive {
+impl Walk {
     pub fn new(path: &str) -> Result<Self, RmError> {
         if fs::metadata(&path).is_ok() {
             Ok(Self {
@@ -21,7 +21,7 @@ impl Recursive {
     }
 }
 
-impl Recursive {
+impl Walk {
     pub fn search(&self, path: &Path, nm_map: &mut NodeModuleMap) -> Result<(), RmError> {
         let entries = fs::read_dir(path)?
             .filter_map(Result::ok)


### PR DESCRIPTION
Filesize enum calculates sizes. Removes use of `rug` crate. Some additional formatting around result messages.

Rename `recursive.rs` and associated naming to `walk.rs`

- feat: filesize enum and impl helper fn
- refactor: rm rug lib and use f64 vals. correct size formatting
- refactor: decimal for end result
